### PR TITLE
Update omnicomplete autocmd checks

### DIFF
--- a/plugin/rhubarb.vim
+++ b/plugin/rhubarb.vim
@@ -163,7 +163,7 @@ endfunction
 augroup rhubarb
   autocmd!
   autocmd User Fugitive
-        \ if &filetype ==# 'gitcommit' && expand('%:t') ==# 'COMMIT_EDITMSG' &&
+        \ if expand('%:p') =~# '.git[\/].*MSG$' &&
         \   exists('+omnifunc') &&
         \   &omnifunc =~# '^\%(syntaxcomplete#Complete\)\=$' &&
         \   join(readfile(fugitive#buffer().repo().dir('config')),"\n")


### PR DESCRIPTION
- drops file type constraint
- explicit file name checks for git commit msg and pull request msg

Related to and closes #5
