### PR TITLE
Fix :Gbrowse for branches with # in the name

### DIFF
--- a/autoload/rhubarb.vim
+++ b/autoload/rhubarb.vim
@@ -227,5 +227,5 @@ function! rhubarb#fugitive_url(opts, ...) abort
   else
     let url = root . '/commit/' . commit
   endif
-  return url
+  return substitute(url, '#', '%23', 'g')
 endfunction


### PR DESCRIPTION
Github does not like urls with # in them. Replacing them with the url encoded version '%23' does the trick.