### PR TITLE
Treat files generated by `hub(1)` as `gitcommit`s

### DIFF
--- a/plugin/rhubarb.vim
+++ b/plugin/rhubarb.vim
@@ -44,6 +44,7 @@ augroup rhubarb
         \ if expand('%') ==# '' && &previewwindow && pumvisible() && getbufvar('#', '&omnifunc') ==# 'rhubarb#omnifunc' |
         \    setlocal nolist linebreak filetype=markdown |
         \ endif
+  autocmd BufNewFile,BufRead *.git/{PULLREQ_EDIT,ISSUE_EDIT,RELEASE_EDIT}MSG set ft=gitcommit
 augroup END
 
 if !exists('g:fugitive_browse_handlers')


### PR DESCRIPTION
- `.git/PULLREQ_EDITMSG` is generated by `hub pull-request`.
- `.git/ISSUE_EDITMSG` is generated by `hub issue create`.
- `.git/RELEASE_EDITMSG` is generated by `hub release create`.