### PR TITLE
Strip trailing slashes from URLs

### DIFF
--- a/autoload/rhubarb.vim
+++ b/autoload/rhubarb.vim
@@ -30,7 +30,7 @@ function! rhubarb#HomepageForUrl(url) abort
   for domain in domains
     let domain_pattern .= '\|' . escape(split(domain, '://')[-1], '.')
   endfor
-  let base = matchstr(a:url, '^\%(https\=://\|git://\|git@\|ssh://git@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
+  let base = matchstr(a:url, '^\%(https\=://\|git://\|git@\|ssh://git@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=/\=$')
   if index(domains, 'http://' . matchstr(base, '^[^:/]*')) >= 0
     return 'http://' . tr(base, ':', '/')
   elseif !empty(base)


### PR DESCRIPTION
Previously if you had a remote in the format:

https://github.com/owner/repo/

When using Gbrowse from fugitive, there would be double slashes in the
opened URL:

https://github.com/owner/repo//blob/master/README.md

This caused GitHub not to show a preview of the lines inline if you
posted it in a comment. This change strips the trailing slash if it
exists.