### PR TITLE
Set a filetype only if unset or wrong

### DIFF
--- a/plugin/rhubarb.vim
+++ b/plugin/rhubarb.vim
@@ -44,7 +44,10 @@ augroup rhubarb
         \ if expand('%') ==# '' && &previewwindow && pumvisible() && getbufvar('#', '&omnifunc') ==# 'rhubarb#omnifunc' |
         \    setlocal nolist linebreak filetype=markdown |
         \ endif
-  autocmd BufNewFile,BufRead *.git/{PULLREQ_EDIT,ISSUE_EDIT,RELEASE_EDIT}MSG set ft=gitcommit
+  autocmd BufNewFile,BufRead *.git/{PULLREQ_EDIT,ISSUE_EDIT,RELEASE_EDIT}MSG
+        \ if &ft ==# '' || &ft ==# 'conf' |
+        \   set ft=gitcommit
+        \ endif
 augroup END
 
 if !exists('g:fugitive_browse_handlers')


### PR DESCRIPTION
It's possible that vim's built-in filetype detection will notice the comment lines and set a filetype of `conf`. This makes using `setfiletype` impractical since `setfiletype` does not override an already set file type.

Based off of https://github.com/tpope/vim-rhubarb/issues/43#issuecomment-504888983

Closes #43 