### PR TITLE
feat: allow overriding hub command

### DIFF
--- a/plugin/rhubarb.vim
+++ b/plugin/rhubarb.vim
@@ -11,8 +11,12 @@ if !exists('g:dispatch_compilers')
 endif
 let g:dispatch_compilers['hub'] = 'git'
 
+if !exists('g:rhubarb_git_command')
+  let g:rhubarb_git_command = 'hub'
+endif
+
 if get(g:, 'fugitive_git_command', 'git') ==# 'git' && executable('hub')
-  let g:fugitive_git_command = 'hub'
+  let g:fugitive_git_command = &g:rhubarb_git_command
 endif
 
 function! s:Config() abort


### PR DESCRIPTION
I'd like to not use the hub command, this allows me to set it back to 'git'.