### PR TITLE
Add support for enterprise cloud accounts

### DIFF
--- a/autoload/rhubarb.vim
+++ b/autoload/rhubarb.vim
@@ -29,7 +29,7 @@ function! rhubarb#HomepageForUrl(url) abort
   for domain in domains
     let domain_pattern .= '\|' . escape(split(substitute(domain, '/$', '', ''), '://')[-1], '.')
   endfor
-  let base = matchstr(a:url, '^\%(https\=://\%([^@/:]*@\)\=\|git://\|git@\|ssh://git@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=/\=$')
+  let base = matchstr(a:url, '^\%(https\=://\%([^@/:]*@\)\=\|git://\|git@\|ssh://git@\|org-\d\+@\|ssh://org-\d\+@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=/\=$')
   if index(domains, 'http://' . matchstr(base, '^[^:/]*')) >= 0
     return 'http://' . tr(base, ':', '/')
   elseif !empty(base)


### PR DESCRIPTION
GitHub Enterprise Cloud accounts use a slightly different URL scheme,
using org-\d+@github.com instead of git@ or ssh@ (or any of the other
supported variations). This adds support for urls with that format to
the base pattern matching so that users with enterprise cloud accounts
can use vim-rhubarb as expected.