### PR TITLE
Improve README.md with information about opening GitHub URLs at specific line numbers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ of features:
 
 * Enables `:GBrowse` from fugitive.vim to open GitHub URLs.
 
-* Enables `:.GBrowse` from fugitive.vim to open GitHub URLs at specific line number.
+* Enables `:.GBrowse` from fugitive.vim to open GitHub URLs at a specific line number.
 
 * In commit messages, GitHub issues, issue URLs, and collaborators can be
   omni-completed (`<C-X><C-O>`, see `:help compl-omni`).  This makes inserting

--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,8 @@ of features:
 
 * Enables `:GBrowse` from fugitive.vim to open GitHub URLs.
 
+* Enables `:.GBrowse` from fugitive.vim to open GitHub URLs at specific line number.
+
 * In commit messages, GitHub issues, issue URLs, and collaborators can be
   omni-completed (`<C-X><C-O>`, see `:help compl-omni`).  This makes inserting
   those `Closes #123` remarks slightly easier than copying and pasting from


### PR DESCRIPTION
# Improve README.md with information about opening GitHub URLs at specific line numbers

Title says it. I'm not familiar w/t all the `fugitive.vim` docs, but I had to look at the `tpope/vim-rhubarb` to find this: https://github.com/tpope/vim-rhubarb/issues/27
