### PR TITLE
add option to yank url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,6 +36,10 @@ If you are using GitHub Enterprise, repeat this step for each domain (omit the
 
     let g:github_enterprise_urls = ['https://example.com']
 
+If you also want to yank the url, set:
+
+    let g:rhubarb_yank_url = 1
+
 ## FAQ
 
 > How do I turn off that preview window that shows the issue body?

--- a/autoload/rhubarb.vim
+++ b/autoload/rhubarb.vim
@@ -331,6 +331,9 @@ function! rhubarb#FugitiveUrl(...) abort
   else
     let url = root . '/commit/' . commit
   endif
+  if get(g:, 'rhubarb_yank_url', 0)
+    let @+ = url
+  endif
   return url
 endfunction
 


### PR DESCRIPTION
Hi Tim,

I am not sure if this is the right place, but my use case for this PR is that I just want to yank the (Github) URL, rather than open it in a web browser.

I had a look at both fugitive and this plugin but since I am very noob to vimscript, it looks easier for me just to put it here. Please correct me, or suggest where should I go about this.

Btw, thanks a heap for all the amazing works.